### PR TITLE
Fixed typos

### DIFF
--- a/Lecture2/Lecture2.tex
+++ b/Lecture2/Lecture2.tex
@@ -486,7 +486,7 @@ conditioning on X we have that
  R(Y,f(X)|X) &= E_X E_{Y|X} [(Y-f(X))^2|X]
 \end{align}
 
-this risk is also know as the {\bf mean squared (prediction) error} $MSE(f)$ 
+this risk is also known as the {\bf mean squared (prediction) error} $MSE(f)$ 
 \end{frame}
 %----------------------------------------------------------------------%
 
@@ -525,7 +525,7 @@ FOC
 Dividing by -2 and reorganizing
 \medskip
 \begin{align}
- m \int (y) dy = \int y f(y)  dy
+ m \int f(y) dy = \int y f(y)  dy
 \end{align}
 
 


### PR DESCRIPTION
Fixed two typos on slides 14 and 16:
- "n" missing in "known"
- "f" missing in "f(y)" 

zv.marin