### PR TITLE
Update Lecture6.tex

### DIFF
--- a/Lecture06/Lecture6.tex
+++ b/Lecture06/Lecture6.tex
@@ -381,7 +381,7 @@ FOC
 
 
 \begin{align}
-\sum_{i=1}^{n}\left(x_{i}-\hat{\mu}\right)=0
+\sum_{i=1}^{n}\left(x_{i}-\mu \right)=0
 \end{align}
 
 then
@@ -475,7 +475,7 @@ The ML estimators for $\beta$ and $\sigma$ result from maximizing this last line
 The first step in maximizing $l(y|\beta,\sigma,X)$ is to {\bf concentrate} it with respect to $\sigma$
 
 \begin{align}
-\frac{\partial l}{\partial \sigma}&=-\frac{n}{2\sigma}+\frac{1}{\sigma^3}(y-X\beta)'(y-X\beta)=0
+\frac{\partial l}{\partial \sigma}&=-\frac{n}{\sigma}+\frac{1}{\sigma^3}(y-X\beta)'(y-X\beta)=0
 \end{align}
 
 Solving for $\sigma^2$


### PR DESCRIPTION
\mu sin hat.

cuando  se tiene deriva contra sigma se va el 2 ya que esta al cuadrado